### PR TITLE
Remove >=

### DIFF
--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -1,4 +1,4 @@
 #' @import basilisk
 env_macs <- BasiliskEnvironment("env_macs", pkgname="MACSr",
-                                packages = c("numpy>=1.17"),
+                                packages = c("numpy=1.17"),
                                 pip = c("macs3==3.0.0a6"))


### PR DESCRIPTION
basilisk no longer allows >/< when specifying package versions, only = or ==
https://github.com/LTLA/basilisk/issues/17